### PR TITLE
feat!: auto-detect version from `*.tera` files

### DIFF
--- a/.github/templates/one.tera
+++ b/.github/templates/one.tera
@@ -1,4 +1,4 @@
 ---
 whiskers:
-  version: 2.3.1
+  version: ^2.3.1
 ---

--- a/.github/templates/one.tera
+++ b/.github/templates/one.tera
@@ -1,0 +1,4 @@
+---
+whiskers:
+  version: 2.3.1
+---

--- a/.github/templates/three.tera
+++ b/.github/templates/three.tera
@@ -1,4 +1,4 @@
 ---
 whiskers:
-  version: 2.4.0
+  version: ^2.4.0
 ---

--- a/.github/templates/three.tera
+++ b/.github/templates/three.tera
@@ -1,0 +1,4 @@
+---
+whiskers:
+  version: 2.4.0
+---

--- a/.github/templates/two.tera
+++ b/.github/templates/two.tera
@@ -1,0 +1,4 @@
+---
+whiskers:
+  version: 2.0.0
+---

--- a/.github/templates/two.tera
+++ b/.github/templates/two.tera
@@ -1,4 +1,4 @@
 ---
 whiskers:
-  version: 2.0.0
+  version: ^2.0.0
 ---

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            version: "2.5.0" # should be 2.5.0
+            version: "2.5.0" # should be 2.5.1
           - os: windows-latest
-            version: "2" # should be 2.5.0
+            version: "2" # should be 2.5.1
           - os: macos-latest
             version: "2.1" # should be 2.1.1
             

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            version: "2.5.0" # should be 2.5.1
+            version: "^2" # should be latest 2.x
           - os: windows-latest
-            version: "2" # should be 2.5.1
+            version: "2.5.0" # should be 2.5.0
           - os: macos-latest
-            version: "2.1" # should be 2.1.1
+            version: "2.3" # should be 2.3.0
             
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,17 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  with-input:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             version: "2.5.0" # should be 2.5.0
-          - os: macos-latest
-            version: "2.1" # should be 2.1.1
           - os: windows-latest
             version: "2" # should be 2.5.0
-          - os: macos-12
-            version: "1.x" # should be 1.1.4
+          - os: macos-latest
+            version: "2.1" # should be 2.1.1
             
 
     runs-on: ${{ matrix.os }}
@@ -31,3 +29,11 @@ jobs:
         with:
           whiskers-version: ${{ matrix.version }}
       - run: whiskers --version
+
+  without-input:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup catppuccin/whiskers
+        uses: ./
+      - run: whiskers --version # should be latest 2.x

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ author: "Catppuccin Org"
 inputs:
   whiskers-version:
     description: "Semver compatible version of catppuccin/whiskers to install"
+    required: false
   github-token:
     description: "GitHub token to use for authentication when installing catppuccin/whiskers"
     required: false
@@ -13,10 +14,57 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: sgoudham/setup-crate@feat/support-unzipped-binaries-diverged
-      with:
-        repo: catppuccin/whiskers@${{ inputs.whiskers-version }}
-        github-token: ${{ inputs.github-token }}
+    # https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+    - name: Install GitHub CLI
+      shell: bash
+      if: ${{ env.ACT && runner.os == 'Linux' && !inputs.whiskers-version }}
+      run: |
+        (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+          && sudo mkdir -p -m 755 /etc/apt/keyrings \
+          && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+          && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+          && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+          && sudo apt update \
+          && sudo apt install gh -y
+
+    - name: Extract versions from `*.tera` files
+      if: ${{ !inputs.whiskers-version }}
+      id: find
+      shell: bash
+      run: |
+        echo "VERSION_REQUIREMENTS=$(find . -name "*.tera" -exec sh -c '
+          FILE={}
+          VERSION=$(sed -n "/^---$/,/^---$/p" "$FILE" | yq eval ".whiskers.version" - | head -n 1)
+          echo \"$VERSION\"
+        ' \; | jq -sc)" >> "$GITHUB_OUTPUT"
+
+    - name: Retrieve versions of catppuccin/whiskers
+      if: ${{ !inputs.whiskers-version }}
+      shell: bash
+      id: ghapi
+      run: |
+        echo "WHISKERS_VERSIONS=$(gh api -XGET -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/catppuccin/whiskers/releases -F per_page=100 | jq -c '[.[].tag_name]')" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Download cargo-binstall
+      uses: cargo-bins/cargo-binstall@main
+
+    - name: Download sgoudham/what-version
+      if: ${{ !inputs.whiskers-version }}
+      shell: bash
+      run: cargo-binstall what-version --version 1.0.0 --no-confirm
+
+    - name: Get Chosen Version
+      if: ${{ !inputs.whiskers-version }}
+      shell: bash
+      id: what_version
+      run: what-version ${{ toJson(steps.find.outputs.VERSION_REQUIREMENTS) }} ${{ toJson(steps.ghapi.outputs.WHISKERS_VERSIONS) }}
+
+    - name: Download catppuccin/whiskers
+      shell: bash
+      run: cargo-binstall catppuccin-whiskers --version ${{ inputs.whiskers-version || steps.what_version.outputs.WHAT_VERSION }}  --no-confirm
 
 branding:
   icon: "dollar-sign"

--- a/action.yml
+++ b/action.yml
@@ -60,11 +60,16 @@ runs:
       if: ${{ !inputs.whiskers-version }}
       shell: bash
       id: what_version
-      run: what-version ${{ toJson(steps.find.outputs.VERSION_REQUIREMENTS) }} ${{ toJson(steps.ghapi.outputs.WHISKERS_VERSIONS) }}
+      run: what-version "$VERSION_REQUIREMENTS" "$WHISKERS_VERSIONS"
+      env:
+        VERSION_REQUIREMENTS: ${{ steps.find.outputs.VERSION_REQUIREMENTS }}
+        WHISKERS_VERSIONS: ${{ steps.ghapi.outputs.WHISKERS_VERSIONS }}
 
     - name: Download catppuccin/whiskers
       shell: bash
-      run: cargo-binstall catppuccin-whiskers --version ${{ inputs.whiskers-version || steps.what_version.outputs.WHAT_VERSION }}  --no-confirm
+      run: cargo-binstall catppuccin-whiskers --version "$WHISKERS_VERSION" --no-confirm
+      env:
+        WHISKERS_VERSION: ${{ inputs.whiskers-version || steps.what_version.outputs.WHAT_VERSION }}
 
 branding:
   icon: "dollar-sign"


### PR DESCRIPTION
This technically isn't a breaking change but I'd like to preserve the `v1` tag for the older behaviour since this is quite a big jump in complexity.

Ultimately, this action is only used within Catppuccin so it's all good.